### PR TITLE
Add github url to go.mod -> able to using go install instead of manually git clone and build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.exe
+gitfetch

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gitfetch
+module github.com/newbee1905/gitfetch
 
 go 1.17
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/newbee1905/gitfetch
+module github.com/SynAcktraa/gitfetch
 
 go 1.17
 

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Only go is needed compile. There is no other dependencies.
 Install:
 
 ```sh
-go install github.com/newbee1905/gitfetch@master
+go install github.com/SynAcktraa/gitfetch@master
 ```
 
 Build:

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,12 @@
 
 Only go is needed compile. There is no other dependencies.
 
+Install:
+
+```sh
+go install github.com/newbee1905/gitfetch@master
+```
+
 Build:
 
 ```sh


### PR DESCRIPTION
- Current problem: Have to use url@master instead of url@latest since I don't know much about git tags. 
- Using url@latest right now, go will still try using v1 which hasn't been updated with your GitHub link inside go.mod